### PR TITLE
Build multiarchitecture docker image

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,5 +1,4 @@
 steps:
-  - label: "Build and Push Dockerfiles"
+  - label: "Build and Push Docker images"
     command:
-      - "docker build -t $REGISTRY_URI:$DOCKER_TAG --build-arg SHORT_COMMIT_HASH=$SHORT_COMMIT_HASH ."
-      - "docker push $REGISTRY_URI:$DOCKER_TAG"
+      - "build.sh"

--- a/build.sh
+++ b/build.sh
@@ -3,7 +3,6 @@
 set -euo pipefail
 
 SUPPORTED_ARCHS="amd64 arm64"
-REGISTRY_URI="${REGISTRY_URI:-887832589804.dkr.ecr.us-west-1.amazonaws.com/image-server}"
 APP_REPO_TAG=$REGISTRY_URI:$DOCKER_TAG
 
 # build individual architectures
@@ -17,14 +16,15 @@ for ARCH in $SUPPORTED_ARCHS; do
   ALL_ARCH_TAGS="$ALL_ARCH_TAGS $TAG"
 done
 
-# create multi-arch manifest
+# Create multi-arch manifest
 echo "*** Creating manifest and pushing $APP_REPO_TAG ***"
 docker manifest create $APP_REPO_TAG $ALL_ARCH_TAGS
 for ARCH in $SUPPORTED_ARCHS; do
   docker manifest annotate --arch $ARCH $APP_REPO_TAG $APP_REPO_TAG-$ARCH
 done
-
 docker manifest push $APP_REPO_TAG
+
+# Annotate build
 if [ -x "$(command -v buildkite-agent)" ]; then
-  buildkite-agent annotate "Image tag: $BGH_RETURNLY_DOCKER_TAG" --style 'info' --context 'build-info'
+  buildkite-agent annotate "Image: $APP_REPO_TAG" --style 'info' --context 'build-info'
 fi

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+set -euo pipefail
+
+SUPPORTED_ARCHS="amd64 arm64"
+REGISTRY_URI="${REGISTRY_URI:-887832589804.dkr.ecr.us-west-1.amazonaws.com/image-server}"
+APP_REPO_TAG=$REGISTRY_URI:$DOCKER_TAG
+
+# build individual architectures
+ALL_ARCH_TAGS=""
+for ARCH in $SUPPORTED_ARCHS; do
+  echo "*** Building for $ARCH ***"
+  TAG=$APP_REPO_TAG-$ARCH
+  docker build --pull -t $TAG --platform $ARCH .
+  echo "*** Pushing $TAG ***"
+  docker push $TAG
+  ALL_ARCH_TAGS="$ALL_ARCH_TAGS $TAG"
+done
+
+# create multi-arch manifest
+echo "*** Creating manifest and pushing $APP_REPO_TAG ***"
+docker manifest create $APP_REPO_TAG $ALL_ARCH_TAGS
+for ARCH in $SUPPORTED_ARCHS; do
+  docker manifest annotate --arch $ARCH $APP_REPO_TAG $APP_REPO_TAG-$ARCH
+done
+
+docker manifest push $APP_REPO_TAG
+if [ -x "$(command -v buildkite-agent)" ]; then
+  buildkite-agent annotate "Image tag: $BGH_RETURNLY_DOCKER_TAG" --style 'info' --context 'build-info'
+fi


### PR DESCRIPTION
Update BK pipeline to build multiarchitecture images for `image-server`.

## Test 🧪 
We need to test this both in M1 and intel chipsets:
### Intel
#### Command
1. 
```shell
. awslogin MFA_CODE
aws ecr get-login-password --region us-west-1 | docker login --username AWS --password-stdin 887832589804.dkr.ecr.us-west-1.amazonaws.com
docker run --rm -p 127.0.0.1:7713:7000 887832589804.dkr.ecr.us-west-1.amazonaws.com/image-server:branch-3355b9a
```
2. Check for errors and make sure in the Docker dashboard it's not emulating `amd64` chipset:
![image](https://user-images.githubusercontent.com/1821052/155166923-82e2d545-87d7-4c23-a9ef-130978afc19c.png)

3. open http://localhost:7713 and make sure the service is runing
#### Result ✅ 
![image](https://user-images.githubusercontent.com/1821052/155168800-6d376b55-ac74-415f-b2b4-49e9f37698c0.png)
![image](https://user-images.githubusercontent.com/1821052/155168829-d79ccc08-a7d5-4297-a370-cab6b47579b4.png)
![image](https://user-images.githubusercontent.com/1821052/155168907-0115e3d4-b696-4af7-8da0-a29508d2d592.png)


### M1
#### Command
1. 
```shell
. awslogin MFA_CODE
aws ecr get-login-password --region us-west-1 | docker login --username AWS --password-stdin 887832589804.dkr.ecr.us-west-1.amazonaws.com
docker run --rm -p 127.0.0.1:7713:7000 887832589804.dkr.ecr.us-west-1.amazonaws.com/image-server:branch-3355b9a
```
2. Check for errors and make sure in the Docker dashboard it's not emulating `amd64` chipset:
![image](https://user-images.githubusercontent.com/1821052/155166923-82e2d545-87d7-4c23-a9ef-130978afc19c.png)

3. open http://localhost:7713 and make sure the service is runing
#### Result