### PR TITLE
[RETURN-12809] Image server should return files with only allowed

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -121,15 +121,15 @@ func serverConfigurationFromConfig() *core.ServerConfiguration {
 		}
 	}
 
-	var whitelistedExtensions = []string{}
+	var allowedExtensions = []string{}
 
 	// Need to check if the string is empty because strings.Split("") returns a slice with one element
 	if len(config.extensions) > 0 {
-		whitelistedExtensions = strings.Split(config.extensions, ",")
+		allowedExtensions = strings.Split(config.extensions, ",")
 	}
 
 	return &core.ServerConfiguration{
-		WhitelistedExtensions: whitelistedExtensions,
+		AllowedExtensions: allowedExtensions,
 		LocalBasePath:         config.localBasePath,
 
 		MaximumWidth:   config.maximumWidth,

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -121,8 +121,15 @@ func serverConfigurationFromConfig() *core.ServerConfiguration {
 		}
 	}
 
+	var whitelistedExtensions = []string{}
+
+	// Need to check if the string is empty because strings.Split("") returns a slice with one element
+	if len(config.extensions) > 0 {
+		whitelistedExtensions = strings.Split(config.extensions, ",")
+	}
+
 	return &core.ServerConfiguration{
-		WhitelistedExtensions: strings.Split(config.extensions, ","),
+		WhitelistedExtensions: whitelistedExtensions,
 		LocalBasePath:         config.localBasePath,
 
 		MaximumWidth:   config.maximumWidth,

--- a/core/server_configuration.go
+++ b/core/server_configuration.go
@@ -7,7 +7,7 @@ import (
 
 // ServerConfiguration struct
 type ServerConfiguration struct {
-	WhitelistedExtensions []string
+	AllowedExtensions []string
 	MaximumWidth          int
 	LocalBasePath         string
 	RemoteBasePath        string

--- a/parser/name_parser.go
+++ b/parser/name_parser.go
@@ -7,13 +7,15 @@ import (
 	"github.com/image-server/image-server/core"
 )
 
-var reR, reS, reW, reF *regexp.Regexp
+var reR, reS, reW, reF, reFormat *regexp.Regexp
 
 func init() {
-	reR = regexp.MustCompile(`^([0-9]+)x([0-9]+)(?:-q([0-9]+))?\.(\w{3,4})$`)
-	reS = regexp.MustCompile(`^x([0-9]+)(?:-q([0-9]+))?\.(\w{3,4})$`)
-	reW = regexp.MustCompile(`^w([0-9]+)(?:-q([0-9]+))?\.(\w{3,4})$`)
-	reF = regexp.MustCompile(`^full_size(?:-q([0-9]+))?\.(\w{3,4})$`)
+	reR = regexp.MustCompile(`^([0-9]+)x([0-9]+)(?:-q([0-9]+))?\.(\w{3,5})$`)
+	reS = regexp.MustCompile(`^x([0-9]+)(?:-q([0-9]+))?\.(\w{3,5})$`)
+	reW = regexp.MustCompile(`^w([0-9]+)(?:-q([0-9]+))?\.(\w{3,5})$`)
+	reF = regexp.MustCompile(`^full_size(?:-q([0-9]+))?\.(\w{3,5})$`)
+	// Custom file name i.e. original.png, some-image-name.png, my-file.png
+	reFormat = regexp.MustCompile(`^.+\.(\w{3,5})$`)
 }
 
 func NameToConfiguration(sc *core.ServerConfiguration, filename string) (*core.ImageConfiguration, error) {
@@ -33,7 +35,11 @@ func NameToConfiguration(sc *core.ServerConfiguration, filename string) (*core.I
 		m := reF.FindStringSubmatch(filename)
 		w, h, q, f = "0", "0", m[1], m[2]
 	} else {
-		return &core.ImageConfiguration{Filename: filename}, nil
+		if reFormat.MatchString(filename) {
+			f = reFormat.FindStringSubmatch(filename)[1]
+		}
+
+		return &core.ImageConfiguration{Filename: filename, Format: f}, nil
 	}
 
 	width, _ := strconv.Atoi(w)

--- a/server/resize_handler.go
+++ b/server/resize_handler.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
@@ -30,6 +31,11 @@ func ResizeHandler(w http.ResponseWriter, req *http.Request, sc *core.ServerConf
 		return
 	}
 
+	if isFormatForbidden(ic.Format, sc) {
+		errorHandler(errors.New("Not Found"), w, req, http.StatusNotFound)
+		return
+	}
+
 	ic.ID = varsToHash(vars)
 	ic.Namespace = vars["namespace"]
 
@@ -56,4 +62,18 @@ func ResizeHandler(w http.ResponseWriter, req *http.Request, sc *core.ServerConf
 
 func varsToHash(vars map[string]string) string {
 	return fmt.Sprintf("%s%s%s%s", vars["id1"], vars["id2"], vars["id3"], vars["id4"])
+}
+
+func isFormatForbidden(format string, sc *core.ServerConfiguration) bool {
+	if format == "" || len(sc.WhitelistedExtensions) == 0 {
+		return false
+	}
+
+	for _, ext := range sc.WhitelistedExtensions {
+		if ext == format {
+			return false
+		}
+	}
+
+	return true
 }

--- a/server/resize_handler.go
+++ b/server/resize_handler.go
@@ -65,11 +65,11 @@ func varsToHash(vars map[string]string) string {
 }
 
 func isFormatForbidden(format string, sc *core.ServerConfiguration) bool {
-	if format == "" || len(sc.WhitelistedExtensions) == 0 {
+	if format == "" || len(sc.AllowedExtensions) == 0 {
 		return false
 	}
 
-	for _, ext := range sc.WhitelistedExtensions {
+	for _, ext := range sc.AllowedExtensions {
 		if ext == format {
 			return false
 		}

--- a/start.sh
+++ b/start.sh
@@ -10,4 +10,4 @@ REMOTE_BASE_URL=${REMOTE_BASE_URL:-https://s3-${AWS_REGION}.amazonaws.com/${AWS_
 mkdir -p /opt/image-server/public
 cp -r /opt/image-server/sample/* /opt/image-server/public
 rm -rf /opt/image-server/sample
-exec bin/image-server server --local_base_path ${LOCAL_BASE_PATH} --uploader ${UPLOADER} --aws_bucket ${AWS_S3_BUCKET} --aws_region ${AWS_REGION} --listen ${SERVER_LISTEN} --remote_base_url ${REMOTE_BASE_URL} --extensions "${WHITELISTED_EXTENSIONS}" ${CUSTOM_FLAGS}
+exec bin/image-server server --local_base_path ${LOCAL_BASE_PATH} --uploader ${UPLOADER} --aws_bucket ${AWS_S3_BUCKET} --aws_region ${AWS_REGION} --listen ${SERVER_LISTEN} --remote_base_url ${REMOTE_BASE_URL} --extensions "${ALLOWED_EXTENSIONS}" ${CUSTOM_FLAGS}

--- a/start.sh
+++ b/start.sh
@@ -10,4 +10,4 @@ REMOTE_BASE_URL=${REMOTE_BASE_URL:-https://s3-${AWS_REGION}.amazonaws.com/${AWS_
 mkdir -p /opt/image-server/public
 cp -r /opt/image-server/sample/* /opt/image-server/public
 rm -rf /opt/image-server/sample
-exec bin/image-server server --local_base_path ${LOCAL_BASE_PATH} --uploader ${UPLOADER} --aws_bucket ${AWS_S3_BUCKET} --aws_region ${AWS_REGION} --listen ${SERVER_LISTEN} --remote_base_url ${REMOTE_BASE_URL} ${CUSTOM_FLAGS}
+exec bin/image-server server --local_base_path ${LOCAL_BASE_PATH} --uploader ${UPLOADER} --aws_bucket ${AWS_S3_BUCKET} --aws_region ${AWS_REGION} --listen ${SERVER_LISTEN} --remote_base_url ${REMOTE_BASE_URL} --extensions "${WHITELISTED_EXTENSIONS}" ${CUSTOM_FLAGS}


### PR DESCRIPTION
- add whitelisted file extensions functionality
- change format regexp to be {3,5}. this allows to find extensions like `DEBUG`